### PR TITLE
Bumped Microsoft.Azure.Functions.ExtensionBundle version

### DIFF
--- a/api-starter/host.json
+++ b/api-starter/host.json
@@ -2,6 +2,6 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[2.*, 3.0.0)"
   }
 }


### PR DESCRIPTION
Following the tutorial found [here](https://docs.microsoft.com/nb-no/learn/modules/publish-static-web-app-api-preview-url/?WT.mc_id=cloudskillschallenge_34f240f3-566f-424c-82fe-01672466d00f) I ran into the following error message when attempting to run `func start` in the _api_ folder.

A host error has occurred during startup operation '5da8d60d-ef57-4cf8-9a96-23a1973a5311'.
[2021-12-08T10:37:27.005Z] Microsoft.Azure.WebJobs.Script: Referenced bundle Microsoft.Azure.Functions.ExtensionBundle of version 1.8.1 does not meet the required minimum version of 2.6.1. Update your extension bundle reference in host.json to reference 2.6.1 or later. For more information see https://aka.ms/func-min-bundle-versions.
Value cannot be null. (Parameter 'provider')

Found the solution to this problem [here](https://github.com/Azure/Azure-Functions/issues/1987#issuecomment-952420935). Thus I created this PR to bump the version.
