### PR TITLE
Update to Azure Functions extension bundle v2

### DIFF
--- a/api-starter/host.json
+++ b/api-starter/host.json
@@ -2,6 +2,6 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[2.*, 3.0.0)"
   }
 }


### PR DESCRIPTION
To avoid [minimum version error](https://github.com/Azure/Azure-Functions/issues/1987) from Core Tools v4 about extensions in bundle v1.

@simonaco 